### PR TITLE
Save backup files for sent contact form emails

### DIFF
--- a/mail-log/.gitignore
+++ b/mail-log/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/send-mail.php
+++ b/send-mail.php
@@ -66,6 +66,14 @@ $bodyLines = [
 ];
 $body = implode("\n", $bodyLines);
 
+// Guarda una copia local del mensaje para respaldo
+$backupDir = __DIR__ . '/mail-log';
+if (!is_dir($backupDir)) {
+    @mkdir($backupDir, 0755, true);
+}
+$backupFile = $backupDir . '/' . date('Ymd_His') . '_' . bin2hex(random_bytes(4)) . '.txt';
+@file_put_contents($backupFile, $body);
+
 // Cabeceras
 $headers = [];
 $headers[] = 'MIME-Version: 1.0';


### PR DESCRIPTION
## Summary
- Save each contact form submission to a timestamped file in `mail-log`
- Ignore stored emails via `.gitignore`

## Testing
- `php -l send-mail.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0a3c8800c8322b25b1d5e9648506b