### PR TITLE
Add Google Analytics tag to landing pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-90B8EB5T3F"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-90B8EB5T3F');
+    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CIEXE - Soluciones de evaluación psicométrica</title>

--- a/index_2.html
+++ b/index_2.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-90B8EB5T3F"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-90B8EB5T3F');
+    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CIEXE - Soluciones de evaluación psicométrica</title>


### PR DESCRIPTION
## Summary
- add Google tag (gtag.js) snippet after `<head>` in both landing pages to enable analytics tracking

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/landing_ciexe/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b0a5e1caa48322a8f3a42c404d4bf8